### PR TITLE
Support Russia domain

### DIFF
--- a/src/api/ezviz-api.ts
+++ b/src/api/ezviz-api.ts
@@ -13,6 +13,8 @@ import {
   EZVIZ_AUTH_ENDPOINT,
   EZVIZ_DEVICES_ENDPOINT,
   EZVIZ_SWITCH_STATUS_ENDPOINT,
+  RUSSIA_DOMAIN,
+  RUSSIA_AREA_ID,
 } from './ezviz-constants.js';
 import { sendRequest } from './ezviz-requests.js';
 
@@ -94,6 +96,10 @@ export class EZVIZAPI {
   }
 
   async getDomain(id: number): Promise<string> {
+    if (id === RUSSIA_AREA_ID) {
+      return `https://${RUSSIA_DOMAIN}`;
+    }
+
     const headers = {
       'Content-Type': 'application/x-www-form-urlencoded',
       'clientType': EZVIZ_CLIENT_TYPE,

--- a/src/api/ezviz-constants.ts
+++ b/src/api/ezviz-constants.ts
@@ -6,3 +6,5 @@ export const EZVIZ_AUTH_ENDPOINT = '/v3/users/login/v5';
 export const EZVIZ_DEVICES_ENDPOINT = '/v3/userdevices/v1/resources/pagelist';
 export const EZVIZ_SWITCH_STATUS_ENDPOINT = '/api/device/switchStatus';
 export const API_ENDPOINT_REFRESH = '/v3/apigateway/login';
+export const RUSSIA_AREA_ID = 114;
+export const RUSSIA_DOMAIN = 'apiirus.ezvizru.com';

--- a/test/api/ezviz-api.test.ts
+++ b/test/api/ezviz-api.test.ts
@@ -5,6 +5,7 @@ import { EZVIZConfig } from '../../src/types/config';
 // import { Logging } from 'homebridge';
 import { Credentials } from '../../src/types/login';
 import { sendRequest } from '../../src/api/ezviz-requests';
+import { RUSSIA_AREA_ID, RUSSIA_DOMAIN } from '../../src/api/ezviz-constants';
 
 jest.mock('axios');
 jest.mock('../../src/api/ezviz-requests', () => ({
@@ -83,6 +84,9 @@ describe('EZVIZAPI', () => {
     test('should return credentials on success', async () => {
       const mockResponse = {
         data: {
+          meta: {
+            code: 200,
+          },
           loginSession: {
             sessionId: 'mockSessionId',
             rfSessionId: 'mockRfSessionId',
@@ -103,6 +107,11 @@ describe('EZVIZAPI', () => {
   });
 
   describe('getDomain', () => {
+    test('getDomain should return Russia domain string', async () => {
+      const domain = await ezvizApi.getDomain(RUSSIA_AREA_ID);
+      expect(domain).toBe(`https://${RUSSIA_DOMAIN}`);
+    });
+
     test('getDomain should return domain string', async () => {
       const mockResponse = { data: { domain: 'api.ezviz.com' } };
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue(mockResponse);


### PR DESCRIPTION
### Summary

Some users have reported that devices are not showing up on their account. After some research, it looks like the endpoint that returns the domain for the specified area ID, is returning a wrong domain for Russia.

This PR is handling manually the domain for Russia. I saw a similar thing on the HomeAssistant integration [here](https://github.com/home-assistant/core/blob/377e0a64d16ca7c3c8efe1b376a94290f2d5745d/homeassistant/components/ezviz/const.py) .