### PR TITLE
[FIX] Live view stops after 9 seconds

### DIFF
--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -49,6 +49,8 @@ export async function getSnapshot(url: string, customFfmpeg?: string): Promise<B
 
 export class FfmpegProcess {
   private ff: execa.ExecaChildProcess<string> | undefined;
+  private killTimeout?: NodeJS.Timeout;
+  private startTimeout?: NodeJS.Timeout;
 
   constructor(
     title: string,
@@ -61,8 +63,9 @@ export class FfmpegProcess {
     customFfmpeg?: string,
   ) {
     let started = false;
+    let startedCallback = false;
     const controller = delegate.controller;
-    const cmdOutput = `${title} command: ffmpeg ${command}`;
+    const cmdOutput = `${title} command: ffmpeg ${command.join(' ')}`;
     if (ffmpegDebugOutput) {
       log.info(cmdOutput);
     } else {
@@ -74,44 +77,86 @@ export class FfmpegProcess {
     try {
       this.ff = execa(videoProcessor, command, { env: process.env });
 
+      this.startTimeout = setTimeout(() => {
+        if (!started && callback && !startedCallback) {
+          started = true;
+          startedCallback = true;
+          log.debug(`${title}: Stream start timeout reached, calling callback`);
+          callback();
+        }
+      }, 3000);
+
       this.ff.stderr?.on('data', (data) => {
-        lastOutput = `${title}: ${String(data)}`;
+        const output = String(data);
+        lastOutput = `${title}: ${output}`;
         if (ffmpegDebugOutput) {
           log.info(lastOutput);
         } else {
           log.debug(lastOutput);
         }
 
-        if (!started && lastOutput.includes('frame=')) {
+        if (!started && (output.includes('frame=') || output.includes('fps=') || output.includes('size='))) {
           started = true;
-          if (callback) {
+          if (callback && !startedCallback) {
+            startedCallback = true;
+            if (this.startTimeout) {
+              clearTimeout(this.startTimeout);
+              this.startTimeout = undefined;
+            }
             callback();
           }
         }
       });
 
-      this.ff.on('exit', (code) => {
-        if (code && code !== 0 && callback) {
+      this.ff.stdout?.on('data', (data) => {
+        if (ffmpegDebugOutput) {
+          log.debug(`${title} stdout: ${String(data)}`);
+        }
+      });
+
+      this.ff.on('exit', (code, signal) => {
+        if (this.killTimeout) {
+          clearTimeout(this.killTimeout);
+          this.killTimeout = undefined;
+        }
+        if (this.startTimeout) {
+          clearTimeout(this.startTimeout);
+          this.startTimeout = undefined;
+        }
+
+        if (code !== null && code !== 0 && !signal) {
           const lines = lastOutput.split('\n');
           let output = '';
           if (lines.length > 1) {
             output = lines[lines.length - 2];
-            if (!output.includes('Exiting normally')) {
-              log.error(`${title}: ${output}`);
+            if (!output.includes('Exiting normally') && !output.includes('SIGTERM')) {
+              log.error(`${title} exited with error: ${output}`);
             }
           }
 
-          if (!started) {
-            callback(new Error(output));
+          if (!started && callback && !startedCallback) {
+            startedCallback = true;
+            callback(new Error(output || 'FFmpeg process failed to start'));
           }
-
-          delegate.stopStream(sessionId);
-          controller?.forceStopStreamingSession(sessionId);
         }
+
+        delegate.stopStream(sessionId);
+        controller?.forceStopStreamingSession(sessionId);
+      });
+
+      this.ff.on('error', (error) => {
+        log.error(`${title} process error: ${error.message}`);
+        if (callback && !startedCallback) {
+          startedCallback = true;
+          callback(new Error(`FFmpeg process error: ${error.message}`));
+        }
+        delegate.stopStream(sessionId);
+        controller?.forceStopStreamingSession(sessionId);
       });
     } catch (error) {
       log.error(`[${title}] Failed to start stream: ` + error);
-      if (callback) {
+      if (callback && !startedCallback) {
+        startedCallback = true;
         callback(new Error('ffmpeg process creation failed!'));
         delegate.stopStream(sessionId);
       }
@@ -119,10 +164,21 @@ export class FfmpegProcess {
   }
 
   public stop(): void {
-    this.ff?.stdin?.end();
-    this.ff?.kill('SIGTERM', {
-      forceKillAfterTimeout: 2000,
-    });
+    if (!this.ff) {
+      return;
+    }
+
+    try {
+      this.ff.stdin?.end();
+      this.ff.kill('SIGTERM');
+
+      // Set a timeout to force kill if process doesn't terminate gracefully
+      this.killTimeout = setTimeout(() => {
+        this.ff?.kill('SIGKILL');
+      }, 5000);
+    } catch (error) {
+      // Process might already be dead, ignore the error
+    }
   }
 
   public getStdin(): Writable | null | undefined {


### PR DESCRIPTION
# Fix: Resolve streaming timeout issue that causes video to stop after 9 seconds

## Problem
Users were experiencing a critical issue where video streaming would stop after approximately 9 seconds, making the camera feed unusable for continuous monitoring.

## Changes Made
Enhanced FFmpeg process management with improved stream start detection using multiple patterns, added 3-second timeout protection to ensure callback execution even if stream detection fails, and implemented better error handling with proper error event listeners and improved exit code processing.

Added graceful process termination with SIGTERM followed by SIGKILL timeout, prevented duplicate callback executions, and improved stdout/stderr handling for better debugging. The process cleanup now properly clears timeouts and handles both normal exits and signal-based terminations.