### PR TITLE
Add support for H9c dual camera

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -222,7 +222,7 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
 
       if (device.deviceSubCategory === 'H9c') {
         // Dual camera
-        data.UUID = this.api.hap.uuid.generate(device.deviceSerial + '_2');
+        data.UUID = this.api.hap.uuid.generate(device.deviceSerial + '_1');
         data.DeviceInfo.channelNumber = 201;
         const data2 = {
           ...data,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -219,7 +219,24 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
       } as DeviceData;
 
       devices.push(data);
-    };
+
+      if (device.deviceSubCategory === 'H9c') {
+        // Dual camera
+        data.UUID = this.api.hap.uuid.generate(device.deviceSerial + '_2');
+        data.DeviceInfo.channelNumber = 201;
+        const data2 = {
+          ...data,
+          UUID: this.api.hap.uuid.generate(device.deviceSerial + '_2'),
+          Name: device.name + ' (Secondary)',
+          DeviceInfo: {
+            ...data.DeviceInfo,
+            channelNumber: 101,
+          },
+        } as DeviceData;
+
+        devices.push(data2);
+      }
+    }
 
     return devices;
   }


### PR DESCRIPTION
# Add support for H9c dual camera
Resolves #9.

I referred to this YouTube video for the channel information: https://www.youtube.com/watch?v=Sp2_X5Ar3fk

I have tested it to work and I can see both my cameras in Apple Home now.