### PR TITLE
Add config option for dual cameras

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1431,6 +1431,12 @@
               "description": "The verification code is usually located on the side of the camera.",
               "type": "string",
               "required": true
+            },
+            "dualCamera": {
+              "title": "Dual Camera",
+              "description": "Enable this if your device has multiple physical cameras (e.g., H9c dual camera). This will create separate accessories for each camera lens.",
+              "type": "boolean",
+              "default": false
             }
           }
         }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -204,21 +204,56 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
         }
       }
 
-      const data = {
-        UUID: uuid,
-        Serial: device.deviceSerial,
-        Name: device.name,
-        Type: deviceType,
-        Connection: devicesResponse.CONNECTION[device.deviceSerial],
-        Status: devicesResponse.STATUS[device.deviceSerial],
-        Switches: devicesResponse.SWITCH[device.deviceSerial],
-        P2P: devicesResponse.P2P[device.deviceSerial],
-        ResourceInfo: devicesResponse.resourceInfos.find((resource) => resource.deviceSerial === device.deviceSerial),
-        DeviceInfo: device,
-        HBConfig: deviceConfig,
-      } as DeviceData;
+      // Check if this is a dual camera
+      const isDualCamera = deviceType === DeviceTypes.IPC && (deviceConfig as CameraConfig).dualCamera;
 
-      devices.push(data);
+      if (isDualCamera) {
+        // Create two separate camera accessories for dual camera devices
+        const cameraChannels = [
+          { suffix: '1', channelNumber: 101 },
+          { suffix: '2', channelNumber: 201 },
+        ];
+
+        for (const { suffix, channelNumber } of cameraChannels) {
+          const deviceSerial = `${device.deviceSerial}_${suffix}`;
+          const deviceUuid = this.api.hap.uuid.generate(deviceSerial);
+          const deviceName = `${device.name} - Camera ${suffix}`;
+          const deviceData = { ...device };
+          deviceData.channelNumber = channelNumber;
+
+          const data = {
+            UUID: deviceUuid,
+            Serial: deviceSerial,
+            Name: deviceName,
+            Type: deviceType,
+            Connection: devicesResponse.CONNECTION[device.deviceSerial],
+            Status: devicesResponse.STATUS[device.deviceSerial],
+            Switches: devicesResponse.SWITCH[device.deviceSerial],
+            P2P: devicesResponse.P2P[device.deviceSerial],
+            ResourceInfo: devicesResponse.resourceInfos.find((resource) => resource.deviceSerial === device.deviceSerial),
+            DeviceInfo: deviceData,
+            HBConfig: deviceConfig,
+          } as DeviceData;
+
+          devices.push(data);
+        }
+      } else {
+        const data = {
+          UUID: uuid,
+          Serial: device.deviceSerial,
+          Name: device.name,
+          Type: deviceType,
+          Connection: devicesResponse.CONNECTION[device.deviceSerial],
+          Status: devicesResponse.STATUS[device.deviceSerial],
+          Switches: devicesResponse.SWITCH[device.deviceSerial],
+          P2P: devicesResponse.P2P[device.deviceSerial],
+          ResourceInfo: devicesResponse.resourceInfos.find((resource) => resource.deviceSerial === device.deviceSerial),
+          DeviceInfo: device,
+          HBConfig: deviceConfig,
+        } as DeviceData;
+
+        devices.push(data);
+      }
     };
 
     return devices;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,6 +11,7 @@ export type PlugConfig = DeviceConfig
 
 export interface CameraConfig extends DeviceConfig {
   username: string;
+  dualCamera?: boolean;
 }
 
 export interface EZVIZConfig extends PlatformConfig {


### PR DESCRIPTION
### Summary

Based on this [issue](https://github.com/viguza/homebridge-ezviz/issues/9) and [proposal](https://github.com/viguza/homebridge-ezviz/pull/10), we're adding a new config option for dual cameras so that they get register as 2 different devices.