### PR TITLE
feat: session refresh using refresh token

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "rimraf ./dist && tsc",
     "start": "homebridge -D",
     "lint": "eslint . --max-warnings=0",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint && npm run build && npm test",
     "watch": "npm run build && npm link && nodemon",
     "test": "jest"
   },

--- a/src/api/ezviz-api.ts
+++ b/src/api/ezviz-api.ts
@@ -2,10 +2,10 @@ import axios, { AxiosRequestConfig } from 'axios';
 import querystring from 'querystring';
 import crypto, { randomBytes } from 'crypto';
 import { Logging } from 'homebridge';
-import { Domain, Credentials, Login } from '../types/login.js';
+import { Domain, Credentials, Login, RefreshSession } from '../types/login.js';
 import { ListDevicesResponse } from '../types/devices.js';
 import { EZVIZConfig } from '../types/config.js';
-import { 
+import {
   EZVIZ_CLIENT_TYPE,
   EZVIZ_USER_AGENT,
   EZVIZ_BASE_API_URL,
@@ -15,6 +15,7 @@ import {
   EZVIZ_SWITCH_STATUS_ENDPOINT,
   EZVIZ_DEFENCE_MODE_ENDPOINT,
   EZVIZ_DEFENCE_MODE_GET_ENDPOINT,
+  API_ENDPOINT_REFRESH,
   RUSSIA_DOMAIN,
   RUSSIA_AREA_ID,
   DEFAULT_GROUP_ID,
@@ -114,6 +115,63 @@ export class EZVIZAPI {
     } catch (error) {
       this.log?.error('Unable to login:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Refreshes the session using the refresh token, falling back to full re-authentication
+   * if the refresh token is missing or rejected.
+   * @returns Promise resolving to updated credentials or undefined on failure
+   */
+  async refreshSession(): Promise<Credentials | undefined> {
+    const creds = this.config.credentials;
+
+    if (!creds?.rfSessionId) {
+      this.log?.debug('No refresh token available, falling back to full re-authentication');
+      return this.authenticate();
+    }
+
+    const data = querystring.stringify({
+      cuName: creds.cuName,
+      featureCode: creds.featureCode,
+      refreshSessionId: creds.rfSessionId,
+    });
+
+    const config: AxiosRequestConfig = {
+      method: 'put',
+      url: `${this.config.domain}${API_ENDPOINT_REFRESH}`,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'clientType': EZVIZ_CLIENT_TYPE,
+        'User-Agent': EZVIZ_USER_AGENT,
+        'sessionId': this.sessionId ?? '',
+      },
+      data,
+    };
+
+    try {
+      const response = await axios(config);
+      const result = response.data as RefreshSession;
+
+      if (result.meta?.code !== 200) {
+        this.log?.debug(`Session refresh rejected (code ${result.meta?.code}), falling back to full re-authentication`);
+        return this.authenticate();
+      }
+
+      const updated: Credentials = {
+        sessionId: result.sessionInfo.sessionId,
+        rfSessionId: result.sessionInfo.refreshSessionId,
+        featureCode: creds.featureCode,
+        cuName: creds.cuName,
+      };
+
+      this.sessionId = updated.sessionId;
+      this.config.credentials = updated;
+      this.log?.debug('Session refreshed successfully');
+      return updated;
+    } catch (error) {
+      this.log?.debug('Session refresh failed, falling back to full re-authentication:', error);
+      return this.authenticate();
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -43,13 +43,13 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
       const credentials = await this.authenticate(ezvizAPI);
       
       if (credentials) {
-        // Set up re-authentication every 12 hours
+        // Refresh session every 12 hours (uses refresh token, falls back to full re-auth)
         setInterval(async () => {
-          this.log.debug('Reauthenticating to EZVIZ API');
+          this.log.debug('Refreshing EZVIZ session');
           try {
-            await this.authenticate(ezvizAPI);
+            await ezvizAPI.refreshSession();
           } catch (error) {
-            this.log.error('Re-authentication failed:', error);
+            this.log.error('Session refresh failed:', error);
           }
         }, 3600000 * 12);
         

--- a/test/api/ezviz-api.test.ts
+++ b/test/api/ezviz-api.test.ts
@@ -146,6 +146,100 @@ describe('EZVIZAPI', () => {
     });
   });
 
+  describe('refreshSession', () => {
+    beforeEach(() => {
+      ezvizApi.sessionId = 'mockSessionId';
+    });
+
+    test('should refresh credentials and update sessionId on success', async () => {
+      const mockResponse = {
+        data: {
+          meta: { code: 200 },
+          sessionInfo: {
+            sessionId: 'newSessionId',
+            refreshSessionId: 'newRfSessionId',
+          },
+        },
+      };
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce(mockResponse);
+
+      const credentials = await ezvizApi.refreshSession();
+
+      expect(credentials?.sessionId).toBe('newSessionId');
+      expect(credentials?.rfSessionId).toBe('newRfSessionId');
+      expect(ezvizApi.sessionId).toBe('newSessionId');
+      expect(mockConfig.credentials.sessionId).toBe('newSessionId');
+    });
+
+    test('should preserve featureCode and cuName from existing credentials', async () => {
+      const mockResponse = {
+        data: {
+          meta: { code: 200 },
+          sessionInfo: {
+            sessionId: 'newSessionId',
+            refreshSessionId: 'newRfSessionId',
+          },
+        },
+      };
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce(mockResponse);
+
+      const credentials = await ezvizApi.refreshSession();
+
+      expect(credentials?.featureCode).toBe(mockCredentials.featureCode);
+      expect(credentials?.cuName).toBe(mockCredentials.cuName);
+    });
+
+    test('should fall back to authenticate() when rfSessionId is missing', async () => {
+      mockConfig.credentials = { ...mockCredentials, rfSessionId: undefined as unknown as string };
+      const authenticateSpy = jest.spyOn(ezvizApi, 'authenticate').mockResolvedValueOnce(mockCredentials);
+      const axiosCallsBefore = (axios as jest.MockedFunction<typeof axios>).mock.calls.length;
+
+      await ezvizApi.refreshSession();
+
+      expect(authenticateSpy).toHaveBeenCalledTimes(1);
+      expect((axios as jest.MockedFunction<typeof axios>).mock.calls.length).toBe(axiosCallsBefore);
+    });
+
+    test('should fall back to authenticate() when API returns non-200', async () => {
+      const mockResponse = {
+        data: { meta: { code: 401 } },
+      };
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce(mockResponse);
+      const authenticateSpy = jest.spyOn(ezvizApi, 'authenticate').mockResolvedValueOnce(mockCredentials);
+
+      await ezvizApi.refreshSession();
+
+      expect(authenticateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should fall back to authenticate() on network error', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockRejectedValueOnce(new Error('Network error'));
+      const authenticateSpy = jest.spyOn(ezvizApi, 'authenticate').mockResolvedValueOnce(mockCredentials);
+
+      await ezvizApi.refreshSession();
+
+      expect(authenticateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should send PUT to the refresh endpoint with correct payload', async () => {
+      const mockResponse = {
+        data: {
+          meta: { code: 200 },
+          sessionInfo: { sessionId: 'newSessionId', refreshSessionId: 'newRfSessionId' },
+        },
+      };
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce(mockResponse);
+
+      await ezvizApi.refreshSession();
+
+      expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+        method: 'put',
+        url: expect.stringContaining('/v3/apigateway/login'),
+        data: expect.stringContaining('refreshSessionId=mockRfSessionId'),
+      }));
+    });
+  });
+
   describe('getDeviceList', () => {
     beforeEach(() => {
       ezvizApi.sessionId = 'mockSessionId';


### PR DESCRIPTION
## Summary

- Adds `refreshSession()` to `EZVIZAPI` that calls `PUT /v3/apigateway/login` with the existing refresh token, replacing the full re-authentication that was previously scheduled every 12 hours
- On success, updates both `this.sessionId` and `config.credentials` so all code paths (direct axios calls and `sendRequest`) use the new token
- Falls back to `authenticate()` automatically if the refresh token is missing or the API rejects it
- Adds `npm test` to `prepublishOnly` to gate publishing on a passing test suite

## Changes

- `src/api/ezviz-api.ts` — new `refreshSession()` method
- `src/platform.ts` — scheduled interval calls `refreshSession()` instead of `authenticate()`
- `test/api/ezviz-api.test.ts` — 6 new tests covering all `refreshSession` branches
- `package.json` — `prepublishOnly` now runs lint + build + test

## Test plan

- [ ] `npm test` passes (35 tests)
- [ ] `npm run build` compiles cleanly
- [ ] Smoke tested against live EZVIZ API — domain resolved, initial session obtained, refresh returned a new valid token with `sessionId in sync: true`