### PR TITLE
feat: expand switch types and add camera privacy switch

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1437,7 +1437,13 @@
               "description": "Enable this if your device has multiple physical cameras (e.g., H9c dual camera). This will create separate accessories for each camera lens.",
               "type": "boolean",
               "default": false
-            }
+            },
+            "sleepSwitch": {
+              "title": "Privacy Switch",
+              "description": "Creates a switch accessory that toggles the camera's sleep/privacy mode.",
+              "type": "boolean",
+              "default": false
+            },
           }
         }
       },

--- a/src/accessories/camera-switch.ts
+++ b/src/accessories/camera-switch.ts
@@ -1,0 +1,62 @@
+import type { CharacteristicValue, PlatformAccessory } from 'homebridge';
+
+import type { EZVIZPlatform } from '../platform.js';
+import { EZVIZAPI } from '../api/ezviz-api.js';
+
+/**
+ * Generic camera switch accessory for any EZVIZ DeviceSwitchType.
+ * The switch type, serial, and channel are stored in accessory.context
+ * so a single class handles privacy, infrared, light, etc.
+ */
+export class CameraSwitch {
+  constructor(
+    private readonly api: EZVIZAPI,
+    private readonly platform: EZVIZPlatform,
+    private readonly accessory: PlatformAccessory,
+  ) {
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'EZVIZ')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Camera Switch')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.serial);
+
+    const service = this.accessory.getService(this.platform.Service.Switch) ||
+      this.accessory.addService(this.platform.Service.Switch);
+
+    service.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
+
+    service.getCharacteristic(this.platform.Characteristic.On)
+      .onSet(this.setOn.bind(this))
+      .onGet(this.getOn.bind(this));
+  }
+
+  private get serial(): string {
+    return this.accessory.context.serial;
+  }
+
+  private get switchType(): number {
+    return this.accessory.context.switchType;
+  }
+
+  private get channelNo(): number {
+    return this.accessory.context.channelNo ?? 0;
+  }
+
+  async setOn(value: CharacteristicValue): Promise<void> {
+    try {
+      await this.api.setSwitchState(this.serial, this.switchType, value as boolean, this.channelNo);
+      this.platform.log.debug(`${this.accessory.displayName} set to ${value}`);
+    } catch (error) {
+      this.platform.log.error(`Failed to set ${this.accessory.displayName}:`, error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+  }
+
+  async getOn(): Promise<CharacteristicValue> {
+    try {
+      return await this.api.getSwitchState(this.serial, this.switchType);
+    } catch (error) {
+      this.platform.log.error(`Failed to get ${this.accessory.displayName}:`, error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+  }
+}

--- a/src/accessories/smart-plug.ts
+++ b/src/accessories/smart-plug.ts
@@ -43,7 +43,7 @@ export class SmartPlug {
   async setOnState(value: CharacteristicValue) {
     try {
       const action = value ? true : false;
-      await this.api.setSwitchState(this.accessory.context.device.Serial, SwitchTypes.On, action);
+      await this.api.setSwitchState(this.accessory.context.device.Serial, SwitchTypes.Plug, action);
       this.platform.log.debug(`Successfully set ${this.accessory.context.device.Name} to ${action ? 'ON' : 'OFF'}`);
     } catch (error) {
       this.platform.log.error(`Unable to set switch state for ${this.accessory.context.device.Name}:`, error);
@@ -57,7 +57,7 @@ export class SmartPlug {
    */
   async getOnState(): Promise<CharacteristicValue> {
     try {
-      const state = await this.api.getSwitchState(this.accessory.context.device.Serial, SwitchTypes.On);
+      const state = await this.api.getSwitchState(this.accessory.context.device.Serial, SwitchTypes.Plug);
       this.platform.log.debug(`${this.accessory.context.device.Name} is currently ${state ? 'ON' : 'OFF'}`);
       return state;
     } catch (error) {

--- a/src/api/ezviz-api.ts
+++ b/src/api/ezviz-api.ts
@@ -251,7 +251,7 @@ export class EZVIZAPI {
    * @param type - The switch type
    * @param value - The value to set (true/false)
    */
-  async setSwitchState(serialNumber: string, type: number, value: boolean): Promise<void> {
+  async setSwitchState(serialNumber: string, type: number, value: boolean, channel = 0): Promise<void> {
     if (!serialNumber) {
       throw new Error('Serial number is required');
     }
@@ -265,7 +265,43 @@ export class EZVIZAPI {
       }
     }
 
-    const config: AxiosRequestConfig = {
+    const enable = value ? 1 : 0;
+
+    // v3: PUT /v3/devices/{serial}/{channel}/{enable}/{switchType}/switchStatus
+    // Uses clientType "3" (Android web) and okhttp agent — required by v3 endpoints.
+    const v3Url = `${this.config.domain}/v3/devices/${serialNumber}/${channel}/${enable}/${type}/switchStatus`;
+    const v3Config: AxiosRequestConfig = {
+      method: 'put',
+      url: v3Url,
+      headers: {
+        'sessionId': this.sessionId,
+        'clientType': '3',
+        'featureCode': this.config.credentials?.featureCode ?? '',
+        'User-Agent': 'okhttp/3.12.1',
+        'appId': 'ys7',
+        'clientNo': 'web_site',
+        'lang': 'en',
+      },
+    };
+
+    try {
+      const response = await axios(v3Config);
+      if (response.data?.meta?.code && response.data.meta.code !== 200) {
+        throw new Error(`Switch update failed: ${response.data.meta.code} - ${response.data.meta.message}`);
+      }
+      return;
+    } catch (error) {
+      const axErr = error as { response?: { status?: number; data?: unknown } };
+      const status = axErr.response?.status;
+      this.log?.debug(`v3 switch returned ${status} for type ${type}: ${JSON.stringify(axErr.response?.data)}`);
+      if (status !== 403 && status !== 404) {
+        this.log?.error('Error setting switch state (v3):', error);
+        throw error;
+      }
+    }
+
+    // Legacy fallback: POST /api/device/switchStatus
+    const legacyConfig: AxiosRequestConfig = {
       method: 'post',
       url: `${this.config.domain}${EZVIZ_SWITCH_STATUS_ENDPOINT}`,
       headers: {
@@ -274,24 +310,20 @@ export class EZVIZAPI {
         'user-agent': EZVIZ_USER_AGENT,
       },
       data: querystring.stringify({
-        channel: 0,
-        clientType: 1,
-        enable: value ? 1 : 0,
         serial: serialNumber,
-        type: type,
+        enable: String(enable),
+        type: String(type),
+        channel: String(channel),
       }),
     };
 
     try {
-      const response = await axios(config);
-      
+      const response = await axios(legacyConfig);
       if (response.data?.retcode) {
-        throw new Error(`Switch state update failed: ${response.data.retcode}`);
+        throw new Error(`Switch state update failed (legacy): ${response.data.retcode}`);
       }
-      
-      return response.data;
     } catch (error) {
-      this.log?.error('Error setting switch state:', error);
+      this.log?.error('Error setting switch state (legacy):', error);
       throw error;
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,11 +2,12 @@ import type { API, Characteristic, DynamicPlatformPlugin, Logging, PlatformAcces
 import { SmartPlug } from './accessories/smart-plug.js';
 import { IPCamera } from './accessories/ip-camera.js';
 import { AlarmModeSwitch } from './accessories/alarm-mode-switch.js';
+import { CameraSwitch } from './accessories/camera-switch.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { EZVIZAPI } from './api/ezviz-api.js';
 import { EZVIZConfig, CameraConfig } from './types/config.js';
 import { Credentials } from './types/login.js';
-import { DeviceTypes } from './utils/enums.js';
+import { DeviceTypes, SwitchTypes } from './utils/enums.js';
 import { ListDevicesResponse } from './types/devices.js';
 import { DeviceData } from './types/data.js';
 
@@ -138,6 +139,13 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
         }
 
         this.discoveredCacheUUIDs.push(device.UUID);
+
+        if (device.Type === DeviceTypes.IPC || device.Type === DeviceTypes.CatEye) {
+          const camConfig = device.HBConfig as CameraConfig | undefined;
+          if (camConfig?.sleepSwitch) {
+            this.createCameraSwitch(ezvizAPI, device, SwitchTypes.Sleep, 'Privacy');
+          }
+        }
       }
 
       // Create a single alarm mode switch accessory
@@ -186,6 +194,31 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
     } catch (error) {
       this.log.error(`Error creating accessory for ${accessory.displayName}:`, error);
     }
+  }
+
+  private createCameraSwitch(ezvizAPI: EZVIZAPI, device: DeviceData, switchType: SwitchTypes, label: string) {
+    const uuid = this.api.hap.uuid.generate(`${device.Serial}-switch-${switchType}`);
+    const name = `${device.Name} ${label}`;
+    const channelNo = device.Switches?.find(s => s.type === switchType)?.channelNo ?? 0;
+    const existing = this.accessories.get(uuid);
+
+    if (existing) {
+      this.log.debug(`Restoring existing ${label} switch from cache: ${existing.displayName}`);
+      existing.context.serial = device.Serial;
+      existing.context.switchType = switchType;
+      existing.context.channelNo = channelNo;
+      new CameraSwitch(ezvizAPI, this, existing);
+    } else {
+      this.log.info(`Adding new ${label} switch: ${name}`);
+      const accessory = new this.api.platformAccessory(name, uuid);
+      accessory.context.serial = device.Serial;
+      accessory.context.switchType = switchType;
+      accessory.context.channelNo = channelNo;
+      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      new CameraSwitch(ezvizAPI, this, accessory);
+    }
+
+    this.discoveredCacheUUIDs.push(uuid);
   }
 
   /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -12,6 +12,7 @@ export type PlugConfig = DeviceConfig
 export interface CameraConfig extends DeviceConfig {
   username: string;
   dualCamera?: boolean;
+  sleepSwitch?: boolean;
 }
 
 export interface EZVIZConfig extends PlatformConfig {

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -5,9 +5,26 @@ export enum DeviceTypes {
 }
 
 export enum SwitchTypes {
-  On = 14,
+  AlarmTone = 1,
+  StreamAdaptive = 2,
+  Light = 3,
+  IntelligentAnalysis = 4,
+  Privacy = 7,
+  InfraredLight = 10,
+  Plug = 14,
   Sleep = 21,
   Audio = 22,
+  MobileTracking = 25,
+  AllDayVideo = 29,
+  AutoSleep = 32,
+  AlarmRemindMode = 37,
+  AlarmLight = 303,
+  AlarmLightRelevance = 305,
+  TamperAlarm = 306,
+  WideAngle = 604,
+  DistortionCorrection = 617,
+  Tracking = 650,
+  FeatureTracking = 701,
 }
 
 export enum DefenceMode {

--- a/test/api/ezviz-api.test.ts
+++ b/test/api/ezviz-api.test.ts
@@ -279,10 +279,12 @@ describe('EZVIZAPI', () => {
       expect(axios).toHaveBeenCalled();
     });
 
-    test('should log error if set switch fails', async () => {
-      (axios as jest.MockedFunction<typeof axios>).mockRejectedValueOnce(new Error('Set switch state failed'));
+    test('should log error if v3 switch request fails with non-403 error', async () => {
+      const networkError = new Error('Set switch state failed');
+      (networkError as unknown as { response: { status: number } }).response = { status: 500 };
+      (axios as jest.MockedFunction<typeof axios>).mockRejectedValueOnce(networkError);
       await expect(ezvizApi.setSwitchState('12345', 14, true)).rejects.toThrow('Set switch state failed');
-      expect(mockLog.error).toHaveBeenCalledWith('Error setting switch state:', expect.any(Error));
+      expect(mockLog.error).toHaveBeenCalledWith('Error setting switch state (v3):', expect.any(Error));
     });
 
     test('should throw error if serialNumber is missing', async () => {
@@ -296,9 +298,9 @@ describe('EZVIZAPI', () => {
       expect(mockLog.error).toHaveBeenCalledWith('Failed to authenticate before setting switch state:', expect.any(Error));
     });
 
-    test('should throw error if switch state update fails with retcode', async () => {
-      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce({ data: { retcode: 999 } });
-      await expect(ezvizApi.setSwitchState('12345', 14, true)).rejects.toThrow('Switch state update failed: 999');
+    test('should throw error if v3 switch response contains non-200 meta code', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce({ data: { meta: { code: 400, message: 'Bad Request' } } });
+      await expect(ezvizApi.setSwitchState('12345', 14, true)).rejects.toThrow('Switch update failed: 400');
     });
   });
 


### PR DESCRIPTION
## Summary

- Expands \`SwitchTypes\` enum from 3 entries to 20, matching pyEzvizApi's \`DeviceSwitchType\` (renamed \`On\` → \`Plug\` to align with API naming)
- Adds \`CameraSwitch\` generic accessory that handles any switch type via \`accessory.context.switchType\`, replacing the deleted \`sleep-switch.ts\` WIP
- Adds \`sleepSwitch\` option to \`CameraConfig\`: when enabled, creates a \"Privacy\" switch accessory for the camera that toggles sleep mode (type 21)
- Restores \`channel\` parameter (default 0) to \`setSwitchState\` which was dropped in a previous WIP

## Config

```json
{
  "cameras": [{
    "serial": "ABC123",
    "username": "admin",
    "code": "XXXXXX",
    "sleepSwitch": true
  }]
}
```

This creates a \"Camera Name Privacy\" switch accessory in HomeKit.

## Test plan

- [ ] `npm test` passes (35 tests)
- [ ] `npm run build` compiles cleanly
- [ ] Camera with `sleepSwitch: true` creates a Privacy switch accessory
- [ ] Toggling the switch calls `setSwitchState` with type 21