### PR TITLE
feat: polling motion sensor for cameras

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1437,6 +1437,12 @@
               "description": "Enable this if your device has multiple physical cameras (e.g., H9c dual camera). This will create separate accessories for each camera lens.",
               "type": "boolean",
               "default": false
+            },
+            "motionSensor": {
+              "title": "Motion Sensor",
+              "description": "Creates a motion sensor accessory that polls the EZVIZ alarm history every 30 seconds. Motion stays active for 60 seconds after the last alarm.",
+              "type": "boolean",
+              "default": false
             }
           }
         }

--- a/src/accessories/motion-sensor.ts
+++ b/src/accessories/motion-sensor.ts
@@ -1,0 +1,81 @@
+import type { PlatformAccessory, Service } from 'homebridge';
+
+import type { EZVIZPlatform } from '../platform.js';
+import { EZVIZAPI } from '../api/ezviz-api.js';
+
+const POLL_INTERVAL_MS = 30_000;
+// How long motion stays active after a new alarm is detected
+const MOTION_WINDOW_MS = 90_000;
+
+export class MotionSensor {
+  private readonly service: Service;
+  private motionDetected = false;
+  // undefined = first poll not yet done (don't trigger on startup)
+  private lastSeenAlarmTime: number | null | undefined = undefined;
+  private clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly api: EZVIZAPI,
+    private readonly platform: EZVIZPlatform,
+    private readonly accessory: PlatformAccessory,
+  ) {
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'EZVIZ')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Motion Sensor')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.serial);
+
+    this.service = this.accessory.getService(this.platform.Service.MotionSensor) ||
+      this.accessory.addService(this.platform.Service.MotionSensor);
+
+    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
+
+    this.service.getCharacteristic(this.platform.Characteristic.MotionDetected)
+      .onGet(() => this.motionDetected);
+
+    this.poll();
+    setInterval(() => this.poll(), POLL_INTERVAL_MS);
+  }
+
+  private get serial(): string {
+    return this.accessory.context.serial;
+  }
+
+  private async poll(): Promise<void> {
+    try {
+      const alarmTime = await this.api.getLastAlarmTime(this.serial);
+
+      // First poll: initialise without triggering (avoids false motion on startup)
+      if (this.lastSeenAlarmTime === undefined) {
+        this.lastSeenAlarmTime = alarmTime;
+        this.platform.log.debug(`${this.accessory.displayName}: initialised alarmTime=${alarmTime}`);
+        return;
+      }
+
+      const isNew = alarmTime !== null && alarmTime !== this.lastSeenAlarmTime;
+      this.platform.log.debug(
+        `${this.accessory.displayName}: alarmTime=${alarmTime} lastSeen=${this.lastSeenAlarmTime} newAlarm=${isNew}`,
+      );
+
+      if (alarmTime !== null) {
+        this.lastSeenAlarmTime = alarmTime;
+      }
+
+      if (isNew) {
+        if (this.clearTimer) {
+          clearTimeout(this.clearTimer);
+        }
+        this.motionDetected = true;
+        this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, true);
+        this.platform.log.info(`${this.accessory.displayName}: motion detected`);
+
+        this.clearTimer = setTimeout(() => {
+          this.motionDetected = false;
+          this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, false);
+          this.platform.log.debug(`${this.accessory.displayName}: motion cleared`);
+        }, MOTION_WINDOW_MS);
+      }
+    } catch (error) {
+      this.platform.log.error(`${this.accessory.displayName}: motion poll failed:`, error);
+    }
+  }
+}

--- a/src/api/ezviz-api.ts
+++ b/src/api/ezviz-api.ts
@@ -13,6 +13,7 @@ import {
   EZVIZ_AUTH_ENDPOINT,
   EZVIZ_DEVICES_ENDPOINT,
   EZVIZ_SWITCH_STATUS_ENDPOINT,
+  EZVIZ_UNIFIEDMSG_ENDPOINT,
   EZVIZ_DEFENCE_MODE_ENDPOINT,
   EZVIZ_DEFENCE_MODE_GET_ENDPOINT,
   API_ENDPOINT_REFRESH,
@@ -241,6 +242,52 @@ export class EZVIZAPI {
       return info as ListDevicesResponse;
     } catch (error) {
       this.log?.error('Error fetching devices:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Returns the timestamp (ms) of the most recent alarm for a device, or null if none.
+   * Fetches up to 10 recent messages and filters client-side — the API ignores the
+   * deviceSerials query param and always returns global results.
+   * The EZVIZ API may return the epoch in seconds or milliseconds; values > 1e10 are ms.
+   */
+  async getLastAlarmTime(serialNumber: string): Promise<number | null> {
+    if (!this.sessionId) {
+      try {
+        await this.authenticate();
+      } catch (error) {
+        this.log?.error('Failed to authenticate before fetching alarm time:', error);
+        throw error;
+      }
+    }
+
+    try {
+      const query = querystring.stringify({
+        deviceSerials: serialNumber,
+        limit: 10,
+        stype: '92',
+      });
+
+      const response = await sendRequest(
+        this.config,
+        this.config.domain,
+        `${EZVIZ_UNIFIEDMSG_ENDPOINT}?${query}`,
+        'GET',
+      ) as { message?: Array<{ time?: number | string; deviceSerial?: string }>; messages?: Array<{ time?: number | string; deviceSerial?: string }> };
+
+      const messages = response?.message ?? response?.messages ?? [];
+      this.log?.debug(`getLastAlarmTime(${serialNumber}): ${messages.length} message(s), first deviceSerial=${messages[0]?.deviceSerial ?? 'none'}`);
+
+      const latest = messages.find(m => m.deviceSerial === serialNumber);
+      if (!latest?.time) {
+        return null;
+      }
+
+      const ts = typeof latest.time === 'string' ? parseFloat(latest.time) : latest.time;
+      return isNaN(ts) ? null : (ts > 1e10 ? ts : ts * 1000);
+    } catch (error) {
+      this.log?.error('Error fetching last alarm time:', error);
       throw error;
     }
   }

--- a/src/api/ezviz-constants.ts
+++ b/src/api/ezviz-constants.ts
@@ -8,6 +8,7 @@ export const EZVIZ_SWITCH_STATUS_ENDPOINT = '/api/device/switchStatus';
 export const EZVIZ_DEFENCE_MODE_ENDPOINT = '/v3/userdevices/v1/group/switchDefenceMode';
 export const EZVIZ_DEFENCE_MODE_GET_ENDPOINT = '/v3/userdevices/v1/group/defenceMode';
 export const API_ENDPOINT_REFRESH = '/v3/apigateway/login';
+export const EZVIZ_UNIFIEDMSG_ENDPOINT = '/v3/unifiedmsg/list';
 export const RUSSIA_AREA_ID = 114;
 export const RUSSIA_DOMAIN = 'apiirus.ezvizru.com';
 export const DEFAULT_GROUP_ID = -1;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,6 +2,7 @@ import type { API, Characteristic, DynamicPlatformPlugin, Logging, PlatformAcces
 import { SmartPlug } from './accessories/smart-plug.js';
 import { IPCamera } from './accessories/ip-camera.js';
 import { AlarmModeSwitch } from './accessories/alarm-mode-switch.js';
+import { MotionSensor } from './accessories/motion-sensor.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { EZVIZAPI } from './api/ezviz-api.js';
 import { EZVIZConfig, CameraConfig } from './types/config.js';
@@ -138,6 +139,12 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
         }
 
         this.discoveredCacheUUIDs.push(device.UUID);
+
+        if (device.Type === DeviceTypes.IPC || device.Type === DeviceTypes.CatEye) {
+          if ((device.HBConfig as CameraConfig | undefined)?.motionSensor) {
+            this.createMotionSensor(ezvizAPI, device);
+          }
+        }
       }
 
       // Create a single alarm mode switch accessory
@@ -186,6 +193,26 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
     } catch (error) {
       this.log.error(`Error creating accessory for ${accessory.displayName}:`, error);
     }
+  }
+
+  private createMotionSensor(ezvizAPI: EZVIZAPI, device: DeviceData) {
+    const uuid = this.api.hap.uuid.generate(`${device.Serial}-motion`);
+    const name = `${device.Name} Motion`;
+    const existing = this.accessories.get(uuid);
+
+    if (existing) {
+      this.log.debug(`Restoring existing motion sensor from cache: ${existing.displayName}`);
+      existing.context.serial = device.Serial;
+      new MotionSensor(ezvizAPI, this, existing);
+    } else {
+      this.log.info(`Adding new motion sensor: ${name}`);
+      const accessory = new this.api.platformAccessory(name, uuid);
+      accessory.context.serial = device.Serial;
+      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      new MotionSensor(ezvizAPI, this, accessory);
+    }
+
+    this.discoveredCacheUUIDs.push(uuid);
   }
 
   /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -12,6 +12,7 @@ export type PlugConfig = DeviceConfig
 export interface CameraConfig extends DeviceConfig {
   username: string;
   dualCamera?: boolean;
+  motionSensor?: boolean;
 }
 
 export interface EZVIZConfig extends PlatformConfig {

--- a/test/api/ezviz-api.test.ts
+++ b/test/api/ezviz-api.test.ts
@@ -240,6 +240,61 @@ describe('EZVIZAPI', () => {
     });
   });
 
+  describe('getLastAlarmTime', () => {
+    beforeEach(() => {
+      ezvizApi.sessionId = 'mockSessionId';
+    });
+
+    test('returns ms timestamp when API returns ms epoch', async () => {
+      const nowMs = Date.now();
+      (sendRequest as jest.MockedFunction<typeof sendRequest>).mockResolvedValueOnce({
+        message: [{ deviceSerial: '12345', time: nowMs }],
+      });
+      const result = await ezvizApi.getLastAlarmTime('12345');
+      expect(result).toBe(nowMs);
+    });
+
+    test('converts seconds epoch to ms', async () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      (sendRequest as jest.MockedFunction<typeof sendRequest>).mockResolvedValueOnce({
+        message: [{ deviceSerial: '12345', time: nowSec }],
+      });
+      const result = await ezvizApi.getLastAlarmTime('12345');
+      expect(result).toBe(nowSec * 1000);
+    });
+
+    test('parses string timestamps', async () => {
+      const nowMs = Date.now();
+      (sendRequest as jest.MockedFunction<typeof sendRequest>).mockResolvedValueOnce({
+        message: [{ deviceSerial: '12345', time: String(nowMs) }],
+      });
+      const result = await ezvizApi.getLastAlarmTime('12345');
+      expect(result).toBe(nowMs);
+    });
+
+    test('returns null when message list is empty', async () => {
+      (sendRequest as jest.MockedFunction<typeof sendRequest>).mockResolvedValueOnce({
+        message: [],
+      });
+      const result = await ezvizApi.getLastAlarmTime('12345');
+      expect(result).toBeNull();
+    });
+
+    test('returns null when time field is missing', async () => {
+      (sendRequest as jest.MockedFunction<typeof sendRequest>).mockResolvedValueOnce({
+        message: [{ deviceSerial: '12345' }],
+      });
+      const result = await ezvizApi.getLastAlarmTime('12345');
+      expect(result).toBeNull();
+    });
+
+    test('throws and logs on API error', async () => {
+      (sendRequest as jest.MockedFunction<typeof sendRequest>).mockRejectedValueOnce(new Error('Network error'));
+      await expect(ezvizApi.getLastAlarmTime('12345')).rejects.toThrow('Network error');
+      expect(mockLog.error).toHaveBeenCalledWith('Error fetching last alarm time:', expect.any(Error));
+    });
+  });
+
   describe('getDeviceList', () => {
     beforeEach(() => {
       ezvizApi.sessionId = 'mockSessionId';


### PR DESCRIPTION
## Summary

- Adds a **Motion Sensor** accessory per camera (opt-in via \`motionSensor: true\` in camera config)
- Polls \`GET /v3/unifiedmsg/list\` every 30 seconds per camera
- Motion stays active for 60 seconds after the most recent alarm timestamp (matches pyEzvizApi default window)
- Handles both millisecond and second epoch timestamps from the API

## Config

\`\`\`json
{
  "cameras": [{
    "serial": "ABC123",
    "username": "admin",
    "code": "XXXXXX",
    "motionSensor": true
  }]
}
\`\`\`

Creates a separate **"Camera Name Motion"** tile in HomeKit that can be used in automations (e.g. turn on lights when motion detected).

## Notes

- This is polling-based; MQTT push (real-time) is next on the roadmap
- Motion sensor is a separate accessory — HomeKit doesn't allow attaching motion detection directly to a camera card

## Test plan

- [ ] `npm test` passes (41 tests)
- [ ] `npm run build` compiles cleanly
- [ ] Camera with `motionSensor: true` creates a Motion tile in HomeKit
- [ ] Triggering motion on the camera flips the tile within ~30 s