### PR TITLE
feat: alarm siren switch per camera

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1443,6 +1443,12 @@
               "description": "Creates a motion sensor accessory that polls the EZVIZ alarm history every 30 seconds. Motion stays active for 60 seconds after the last alarm.",
               "type": "boolean",
               "default": false
+            },
+            "sirenSwitch": {
+              "title": "Siren Switch",
+              "description": "Creates a switch accessory that triggers the camera's audible siren. The siren runs for ~30 seconds then auto-stops.",
+              "type": "boolean",
+              "default": false
             }
           }
         }

--- a/src/accessories/alarm-siren.ts
+++ b/src/accessories/alarm-siren.ts
@@ -1,0 +1,68 @@
+import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+
+import type { EZVIZPlatform } from '../platform.js';
+import { EZVIZAPI } from '../api/ezviz-api.js';
+
+// EZVIZ sirens auto-stop after ~30 seconds; reset the switch to OFF after this delay
+const SIREN_AUTO_RESET_MS = 30_000;
+
+export class AlarmSiren {
+  private readonly service: Service;
+  private active = false;
+  private resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly api: EZVIZAPI,
+    private readonly platform: EZVIZPlatform,
+    private readonly accessory: PlatformAccessory,
+  ) {
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'EZVIZ')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Alarm Siren')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.serial);
+
+    this.service = this.accessory.getService(this.platform.Service.Switch) ||
+      this.accessory.addService(this.platform.Service.Switch);
+
+    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
+
+    this.service.getCharacteristic(this.platform.Characteristic.On)
+      .onSet(this.setOn.bind(this))
+      .onGet(() => this.active);
+  }
+
+  private get serial(): string {
+    return this.accessory.context.serial;
+  }
+
+  private async setOn(value: CharacteristicValue): Promise<void> {
+    const enable = value as boolean;
+
+    if (this.resetTimer) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
+
+    try {
+      if (enable) {
+        await this.api.soundAlarm(this.serial);
+        this.active = true;
+        this.platform.log.debug(`${this.accessory.displayName}: siren triggered`);
+
+        // Auto-reset to OFF when the siren times out on the device
+        this.resetTimer = setTimeout(() => {
+          this.active = false;
+          this.service.updateCharacteristic(this.platform.Characteristic.On, false);
+          this.platform.log.debug(`${this.accessory.displayName}: siren auto-reset`);
+        }, SIREN_AUTO_RESET_MS);
+      } else {
+        await this.api.cancelAlarm(this.serial);
+        this.active = false;
+        this.platform.log.debug(`${this.accessory.displayName}: siren cancelled`);
+      }
+    } catch (error) {
+      this.platform.log.error(`${this.accessory.displayName}: failed to ${enable ? 'trigger' : 'cancel'} siren:`, error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+  }
+}

--- a/src/api/ezviz-api.ts
+++ b/src/api/ezviz-api.ts
@@ -14,6 +14,7 @@ import {
   EZVIZ_DEVICES_ENDPOINT,
   EZVIZ_SWITCH_STATUS_ENDPOINT,
   EZVIZ_UNIFIEDMSG_ENDPOINT,
+  EZVIZ_CANCEL_ALARM_ENDPOINT,
   EZVIZ_DEFENCE_MODE_ENDPOINT,
   EZVIZ_DEFENCE_MODE_GET_ENDPOINT,
   API_ENDPOINT_REFRESH,
@@ -391,6 +392,78 @@ export class EZVIZAPI {
     }
 
     return deviceSwitch?.enable;
+  }
+
+  /**
+   * Triggers the audible siren on a camera.
+   * The siren runs for ~30 seconds on the device and then stops automatically.
+   */
+  async soundAlarm(serialNumber: string): Promise<void> {
+    if (!serialNumber) {
+      throw new Error('Serial number is required');
+    }
+    if (!this.sessionId) {
+      await this.authenticate();
+    }
+
+    const config: AxiosRequestConfig = {
+      method: 'put',
+      url: `${this.config.domain}/v3/devices/${serialNumber}/0/sendAlarm`,
+      headers: {
+        'sessionId': this.sessionId,
+        'clientType': '3',
+        'featureCode': this.config.credentials?.featureCode ?? '',
+        'User-Agent': 'okhttp/3.12.1',
+        'appId': 'ys7',
+        'clientNo': 'web_site',
+        'lang': 'en',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      data: querystring.stringify({ enable: 1 }),
+    };
+
+    try {
+      const response = await axios(config);
+      if (response.data?.meta?.code && response.data.meta.code !== 200) {
+        throw new Error(`Sound alarm failed: ${response.data.meta.code} - ${response.data.meta.message}`);
+      }
+    } catch (error) {
+      this.log?.error('Error triggering alarm siren:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Cancels the audible siren on a camera.
+   */
+  async cancelAlarm(serialNumber: string): Promise<void> {
+    if (!serialNumber) {
+      throw new Error('Serial number is required');
+    }
+    if (!this.sessionId) {
+      await this.authenticate();
+    }
+
+    const config: AxiosRequestConfig = {
+      method: 'post',
+      url: `${this.config.domain}${EZVIZ_CANCEL_ALARM_ENDPOINT}`,
+      headers: {
+        'sessionid': this.sessionId,
+        'clienttype': EZVIZ_CLIENT_TYPE,
+        'user-agent': EZVIZ_USER_AGENT,
+      },
+      data: querystring.stringify({ subSerial: serialNumber }),
+    };
+
+    try {
+      const response = await axios(config);
+      if (response.data?.meta?.code && response.data.meta.code !== 200) {
+        throw new Error(`Cancel alarm failed: ${response.data.meta.code} - ${response.data.meta.message}`);
+      }
+    } catch (error) {
+      this.log?.error('Error cancelling alarm siren:', error);
+      throw error;
+    }
   }
 
   /**

--- a/src/api/ezviz-constants.ts
+++ b/src/api/ezviz-constants.ts
@@ -5,6 +5,7 @@ export const EZVIZ_DOMAINS_ENDPOINT = '/api/area/domain';
 export const EZVIZ_AUTH_ENDPOINT = '/v3/users/login/v5';
 export const EZVIZ_DEVICES_ENDPOINT = '/v3/userdevices/v1/resources/pagelist';
 export const EZVIZ_SWITCH_STATUS_ENDPOINT = '/api/device/switchStatus';
+export const EZVIZ_CANCEL_ALARM_ENDPOINT = '/api/device/cancelAlarm';
 export const EZVIZ_DEFENCE_MODE_ENDPOINT = '/v3/userdevices/v1/group/switchDefenceMode';
 export const EZVIZ_DEFENCE_MODE_GET_ENDPOINT = '/v3/userdevices/v1/group/defenceMode';
 export const API_ENDPOINT_REFRESH = '/v3/apigateway/login';

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -3,6 +3,7 @@ import { SmartPlug } from './accessories/smart-plug.js';
 import { IPCamera } from './accessories/ip-camera.js';
 import { AlarmModeSwitch } from './accessories/alarm-mode-switch.js';
 import { MotionSensor } from './accessories/motion-sensor.js';
+import { AlarmSiren } from './accessories/alarm-siren.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { EZVIZAPI } from './api/ezviz-api.js';
 import { EZVIZConfig, CameraConfig } from './types/config.js';
@@ -144,6 +145,9 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
           if ((device.HBConfig as CameraConfig | undefined)?.motionSensor) {
             this.createMotionSensor(ezvizAPI, device);
           }
+          if ((device.HBConfig as CameraConfig | undefined)?.sirenSwitch) {
+            this.createSiren(ezvizAPI, device);
+          }
         }
       }
 
@@ -210,6 +214,26 @@ export class EZVIZPlatform implements DynamicPlatformPlugin {
       accessory.context.serial = device.Serial;
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       new MotionSensor(ezvizAPI, this, accessory);
+    }
+
+    this.discoveredCacheUUIDs.push(uuid);
+  }
+
+  private createSiren(ezvizAPI: EZVIZAPI, device: DeviceData) {
+    const uuid = this.api.hap.uuid.generate(`${device.Serial}-siren`);
+    const name = `${device.Name} Siren`;
+    const existing = this.accessories.get(uuid);
+
+    if (existing) {
+      this.log.debug(`Restoring existing siren from cache: ${existing.displayName}`);
+      existing.context.serial = device.Serial;
+      new AlarmSiren(ezvizAPI, this, existing);
+    } else {
+      this.log.info(`Adding new siren: ${name}`);
+      const accessory = new this.api.platformAccessory(name, uuid);
+      accessory.context.serial = device.Serial;
+      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      new AlarmSiren(ezvizAPI, this, accessory);
     }
 
     this.discoveredCacheUUIDs.push(uuid);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,6 +13,7 @@ export interface CameraConfig extends DeviceConfig {
   username: string;
   dualCamera?: boolean;
   motionSensor?: boolean;
+  sirenSwitch?: boolean;
 }
 
 export interface EZVIZConfig extends PlatformConfig {

--- a/test/api/ezviz-api.test.ts
+++ b/test/api/ezviz-api.test.ts
@@ -241,10 +241,6 @@ describe('EZVIZAPI', () => {
   });
 
   describe('getLastAlarmTime', () => {
-    beforeEach(() => {
-      ezvizApi.sessionId = 'mockSessionId';
-    });
-
     test('returns ms timestamp when API returns ms epoch', async () => {
       const nowMs = Date.now();
       (sendRequest as jest.MockedFunction<typeof sendRequest>).mockResolvedValueOnce({
@@ -292,6 +288,63 @@ describe('EZVIZAPI', () => {
       (sendRequest as jest.MockedFunction<typeof sendRequest>).mockRejectedValueOnce(new Error('Network error'));
       await expect(ezvizApi.getLastAlarmTime('12345')).rejects.toThrow('Network error');
       expect(mockLog.error).toHaveBeenCalledWith('Error fetching last alarm time:', expect.any(Error));
+    });
+  });
+
+  describe('soundAlarm', () => {
+    beforeEach(() => {
+      ezvizApi.sessionId = 'mockSessionId';
+    });
+    
+    test('calls PUT /v3/devices/{serial}/0/sendAlarm with enable=1', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce({ data: { meta: { code: 200 } } });
+      await ezvizApi.soundAlarm('12345');
+      expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+        method: 'put',
+        url: expect.stringContaining('/v3/devices/12345/0/sendAlarm'),
+        data: expect.stringContaining('enable=1'),
+      }));
+    });
+
+    test('throws on non-200 meta code', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce({ data: { meta: { code: 403, message: 'Forbidden' } } });
+      await expect(ezvizApi.soundAlarm('12345')).rejects.toThrow('Sound alarm failed: 403');
+    });
+
+    test('throws and logs on network error', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockRejectedValueOnce(new Error('Network error'));
+      await expect(ezvizApi.soundAlarm('12345')).rejects.toThrow('Network error');
+      expect(mockLog.error).toHaveBeenCalledWith('Error triggering alarm siren:', expect.any(Error));
+    });
+
+    test('throws if serial is missing', async () => {
+      await expect(ezvizApi.soundAlarm('')).rejects.toThrow('Serial number is required');
+    });
+  });
+
+  describe('cancelAlarm', () => {
+    beforeEach(() => {
+      ezvizApi.sessionId = 'mockSessionId';
+    });
+
+    test('calls POST /api/device/cancelAlarm with subSerial', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockResolvedValueOnce({ data: { meta: { code: 200 } } });
+      await ezvizApi.cancelAlarm('12345');
+      expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+        method: 'post',
+        url: expect.stringContaining('/api/device/cancelAlarm'),
+        data: expect.stringContaining('subSerial=12345'),
+      }));
+    });
+
+    test('throws and logs on network error', async () => {
+      (axios as jest.MockedFunction<typeof axios>).mockRejectedValueOnce(new Error('Network error'));
+      await expect(ezvizApi.cancelAlarm('12345')).rejects.toThrow('Network error');
+      expect(mockLog.error).toHaveBeenCalledWith('Error cancelling alarm siren:', expect.any(Error));
+    });
+
+    test('throws if serial is missing', async () => {
+      await expect(ezvizApi.cancelAlarm('')).rejects.toThrow('Serial number is required');
     });
   });
 


### PR DESCRIPTION
## Summary

- `soundAlarm()` — `PUT /v3/devices/{serial}/0/sendAlarm` with v3 headers (clientType 3 / okhttp UA)
- `cancelAlarm()` — `POST /api/device/cancelAlarm` with `subSerial` form param
- New `AlarmSiren` accessory: a Switch that triggers the siren on ON and cancels it on OFF
- Auto-resets the switch to OFF after 30 s (EZVIZ sirens auto-stop on the device)
- Opt-in via `sirenSwitch: true` in camera config

## Config

\`\`\`json
{
  "cameras": [{
    "serial": "ABC123",
    "username": "admin",
    "code": "XXXXXX",
    "sirenSwitch": true
  }]
}
\`\`\`

Useful for automations: "when contact sensor opens at night → trigger siren."

## Test plan

- [ ] `npm test` passes (42 tests)
- [ ] `npm run build` compiles cleanly
- [ ] Camera with `sirenSwitch: true` creates a "Camera Name Siren" switch in HomeKit
- [ ] Toggling ON triggers the audible siren; switch resets to OFF after ~30 s
- [ ] Toggling OFF while siren is active cancels it immediately