### PR TITLE
chore: add Node.js 24 to supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": "^18.20.4 || ^20.18.0 || ^22.10.0",
+    "node": "^18.20.4 || ^20.18.0 || ^22.10.0 || ^24.0.0",
     "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "moduleDirectories": [


### PR DESCRIPTION
Adds `^24.0.0` to the `engines.node` range to fix the version warning on Homebridge installations running Node.js 24.